### PR TITLE
Add option to allow octoprint to expose the metrics on the main port

### DIFF
--- a/octoprint_prometheus/__init__.py
+++ b/octoprint_prometheus/__init__.py
@@ -43,17 +43,17 @@ class PrometheusPlugin(octoprint.plugin.StartupPlugin,
                        octoprint.plugin.EventHandlerPlugin,
                        octoprint.plugin.BlueprintPlugin):
 
-        @octoprint.plugin.BlueprintPlugin.route("/metrics", methods=["GET"])
-        def metrics_proxy(self):
-            self._logger.info("Prometheus Proxy (Exposed: %s)" % bool(self._settings.get(["prometheus_exposed"])))
-            if not bool(self._settings.get(["prometheus_exposed"])):
-                self._logger.info("Prometheus metrics are not exposed")
-                abort(404)
+    @octoprint.plugin.BlueprintPlugin.route("/metrics", methods=["GET"])
+    def metrics_proxy(self):
+        self._logger.info("Prometheus Proxy (Exposed: %s)" % bool(self._settings.get(["prometheus_exposed"])))
+        if not bool(self._settings.get(["prometheus_exposed"])):
+            self._logger.info("Prometheus metrics are not exposed")
+            abort(404)
 
-            conn = httplib.HTTPConnection("localhost", int(self._settings.get(["prometheus_port"])))
-            conn.request("GET", "/metrics")
-            resp = conn.getresponse()
-            return Response(response=resp.read(), status=resp.status, content_type=resp.getheader('content-type'))
+        conn = httplib.HTTPConnection("localhost", int(self._settings.get(["prometheus_port"])))
+        conn.request("GET", "/metrics")
+        resp = conn.getresponse()
+        return Response(response=resp.read(), status=resp.status, content_type=resp.getheader('content-type'))
 
     DESCRIPTIONS = {"octoprint_temperature_bed_actual": "Actual Temperature in Celsius of Bed",
                     "octoprint_temperature_bed__target": "Target Temperature in Celsius of Bed",

--- a/octoprint_prometheus/templates/prometheus_settings.jinja2
+++ b/octoprint_prometheus/templates/prometheus_settings.jinja2
@@ -5,10 +5,10 @@
             <input type="text" class="input-block-level" data-bind="value: settings.plugins.prometheus.prometheus_port">
         </div>
     </div>
-     <div class="control-group">
-         <label class="control-label">{{ _('Expose on main API') }}</label>
-         <div class="controls">
-             <input type="checkbox" class="" data-bind="checked: settings.plugins.prometheus.prometheus_exposed"/>
-         </div>
-     </div>
+    <div class="control-group">
+        <label class="control-label">{{ _('Expose on main API') }}</label>
+        <div class="controls">
+            <input type="checkbox" class="" data-bind="checked: settings.plugins.prometheus.prometheus_exposed"/>
+        </div>
+    </div>
 </form>

--- a/octoprint_prometheus/templates/prometheus_settings.jinja2
+++ b/octoprint_prometheus/templates/prometheus_settings.jinja2
@@ -5,4 +5,10 @@
             <input type="text" class="input-block-level" data-bind="value: settings.plugins.prometheus.prometheus_port">
         </div>
     </div>
+     <div class="control-group">
+         <label class="control-label">{{ _('Expose on main API') }}</label>
+         <div class="controls">
+             <input type="checkbox" class="" data-bind="checked: settings.plugins.prometheus.prometheus_exposed"/>
+         </div>
+     </div>
 </form>


### PR DESCRIPTION
Replaces #3 

@jpweber 

Your update seems to be more active, so offering the change up here too

https://github.com/sbelectronics/octoprint-prometheus/pull/5

I run my octorpint inside of a container and don't want to expose more ports.

So, added an optional (disabled by default) flask endpoint that proxies the metrics data

```
<host>/plugin/prometheus/metrics
```